### PR TITLE
apt: make Version.fetch_binary() less noisy

### DIFF
--- a/apt/package.py
+++ b/apt/package.py
@@ -21,7 +21,7 @@
 """Functionality related to packages."""
 from __future__ import print_function
 
-
+import logging
 import os
 import sys
 import re
@@ -732,7 +732,7 @@ class Version(object):
         base = os.path.basename(self._records.filename)
         destfile = os.path.join(destdir, base)
         if _file_is_same(destfile, self.size, self._records.md5_hash):
-            print(('Ignoring already existing file: %s' % destfile))
+            logging.debug('Ignoring already existing file: %s' % destfile)
             return os.path.abspath(destfile)
         acq = apt_pkg.Acquire(progress or apt.progress.text.AcquireProgress())
         acqfile = apt_pkg.AcquireFile(acq, self.uri, self._records.md5_hash,


### PR DESCRIPTION
The code currently prints unconditionally if the downloaded file
is already available. Instead use the debug logger so that the
information is not lost but also not visible by default.