### PR TITLE
[RFC]: Add private helper to avoid IO on each IndexFile lookup.

### DIFF
--- a/apt/package.py
+++ b/apt/package.py
@@ -337,7 +337,7 @@ class Origin(object):
         self.site = packagefile.site
         self.not_automatic = packagefile.not_automatic
         # check the trust
-        indexfile = pkg._pcache._list.find_index(packagefile)
+        indexfile = pkg._pcache._find_index(packagefile)
         if indexfile and indexfile.is_trusted:
             self.trusted = True
         else:
@@ -793,7 +793,7 @@ class Version(object):
         .. versionadded:: 0.7.10
         """
         for (packagefile, _unused) in self._cand.file_list:
-            indexfile = self.package._pcache._list.find_index(packagefile)
+            indexfile = self.package._pcache._find_index(packagefile)
             if indexfile:
                 yield indexfile.archive_uri(self._records.filename)
 

--- a/apt/utils.py
+++ b/apt/utils.py
@@ -77,7 +77,7 @@ def get_release_filename_for_pkg(cache, pkgname, label, release):
                 ver = aver
     if not ver:
         return None
-    indexfile = cache._list.find_index(ver.file_list[0][0])
+    indexfile = cache._find_index(ver.file_list[0][0])
     for metaindex in cache._list.list:
         for m in metaindex.index_files:
             if (indexfile and


### PR DESCRIPTION
Cache the IndexFile objects in the Cache Object.
Otherwise unattended-upgrades reads the index files onces for each
version of each package.

---
The aim is to speedup unattended-upgrades. cprofile goes from 1900 to 60 cumulated time on this box.

Cache _find_index might is private to the implementation.  apt_pkg.SourceList find_index might be overloaded so external users of this method benefit from the speedup.
I wrapped PackageFile to make it hashable: maybe this should be handled in PackageFile itself.